### PR TITLE
Creates service command interface option the proper way

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ php artisan make:service {YourService} --interface={YourInterface}
 ```
 or 
 ```
-php artisan make:service {YourService} --i={YourInterface}
+php artisan make:service {YourService} -i {YourInterface}
 ```
 
 ### Create an action class:

--- a/src/Console/ServiceMakeCommand.php
+++ b/src/Console/ServiceMakeCommand.php
@@ -10,7 +10,7 @@ class ServiceMakeCommand extends GeneratorCommand
 {
     use FileGenerable;
 
-    protected $signature = 'make:service {name} {--interface=} {--i=}';
+    protected $signature = 'make:service {name} {--i|interface=}';
 
     protected $description = 'Make a service class';
 
@@ -23,8 +23,7 @@ class ServiceMakeCommand extends GeneratorCommand
 
     protected function buildClass($name): string
     {
-        if ($this->option('interface') || $this->option('i')) {
-            $interfaceName = $this->option('interface') ?? $this->option('i');
+        if ($interfaceName = $this->option('interface')) {
             $interfaceUseNamespace = config('artisan-maker.interface_namespace') . '\\' . $interfaceName;
 
             if (!$this->checkInterfaceExists($interfaceUseNamespace)) {


### PR DESCRIPTION
Instead of having two options `--interface` and `--i`, I just made `-i` a shortcut to `--interface`.

Now the command can be called like

```
php artisan make:service SomeService -i SomeInterface
```

or as per usual

```
php artisan make:service SomeService --interface=SomeInterface
```